### PR TITLE
Add `/api/user/<username>` [DELETE] endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Users who want to join the Crystal Prism community can create an account to stor
 ```
 
 **DELETE** /api/user
-* Delete a user's account. No request body is needed. Note that there must be a verified bearer token for the user in the request Authorization header.
+* Soft-delete a user's account as the user (i.e., change the account's status to "deleted" while leaving drawings, posts, scores, personal information, etc. intact, in case the user wants to reactivate the account). No request body is needed. Note that there must be a verified bearer token for the user in the request Authorization header.
 
 **GET** /api/user/[username]
 * Retrieve a user's limited account information. No bearer token is needed in the request Authorization header.
@@ -393,6 +393,9 @@ Users who want to join the Crystal Prism community can create an account to stor
     "username": "user"
 }
 ```
+
+**DELETE** /api/user/[username]
+* Hard-delete a user's account as the user or as an admin user (i.e., delete all of the user's drawings, posts, scores, personal information, etc. in addition to changing the account status to "deleted"). No request body is needed. Note that there must be a verified bearer token for the user or for an admin user in the request Authorization header.
 
 **GET** /api/user/verify
 * Check if a bearer token in a request Authorization header is valid and receive the expiration time (in seconds since epoch) if so.

--- a/server.py
+++ b/server.py
@@ -384,8 +384,4 @@ def users_info():
         if verification.status_code != 200:
             return verification
 
-        # Get username from payload if user is logged in
-        payload = json.loads(verification.data.decode())
-        requester = payload['username']
-
-        return user.read_users(requester)
+        return user.read_users()

--- a/user/user.py
+++ b/user/user.py
@@ -481,6 +481,7 @@ def read_users():
         users = json.load(users_file)
         usernames = [user_data['username']
             for user_data in users[request_start:request_end]
+            if user_data['status'] != 'deleted'
             ]
 
         return jsonify(usernames[request_start:request_end])

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -15,6 +15,9 @@ class CrystalPrismTestCase(unittest.TestCase):
         self.token = ''  # Login JWT token
         self.username = ''  # Username of test user
 
+    def tearDown(self):
+        self.delete_user()
+
     # Create test user
     def create_user(self, username='test' + now, password='password'):
         self.username = username
@@ -39,12 +42,12 @@ class CrystalPrismTestCase(unittest.TestCase):
         self.token = response.get_data(as_text=True)
 
     # Delete test user
-    def delete_user(self):
-        self.login()
+    def delete_user(self, username='test' + now, password='password'):
+        self.login(username, password)
 
         header = {'Authorization': 'Bearer ' + self.token}
 
         response = self.client.delete(
-            '/api/user',
+            '/api/user/' + username,
             headers=header
         )


### PR DESCRIPTION
- Add delete user admin function to delete user and all of user's data stored on server
- Update test utils to include deletion of test user data via delete user admin function
- Update `/api/users` [GET] endpoint to only show non-deleted users
- Remove unnecessary passage of requester to user.read_users() function