### PR TITLE
Add tests for `/api/user` endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,6 @@ Users who want to join the Crystal Prism community can create an account to stor
     "member_id": "UUID", // Random universally unique identifier
     "member_since": "2017-10-04T00:00:00.000000+00:00", // UTC timestamp of when user created account
     "name_public": false, // User specifies if name is viewable on public profile
-    "password": "$2b$12$GD0XvyXV/8i9G1...", // Password hashed with bcrypt algorithm
     "post_count": 1, // Number of user's Thought Writer posts
     "rhythm_high_lifespan": "00:00:00", // High lifespan in Rhythm of Life
     "rhythm_high_score": 0, // High score in Rhythm of Life (lifespan converted to integer)

--- a/canvashare/canvashare.py
+++ b/canvashare/canvashare.py
@@ -70,15 +70,19 @@ def create_drawing(requester):
 
 
 def read_drawing(artist_name, drawing_file):
-    # Convert artist's username to member_id for drawing information retrieval
+    # Convert artist's username to member_id for drawing retrieval
     with open(cwd + '/../user/users.json', 'r') as users_file:
         users = json.load(users_file)
         for user_data in users:
             if user_data['username'].lower() == artist_name.lower():
                 artist_id = user_data['member_id']
 
-    # Send drawing PNG file to client
-    return send_file(cwd + '/drawings/' + artist_id + '/' + drawing_file)
+                # Send drawing PNG file to client
+                return send_file(cwd + '/drawings/' + artist_id + '/' +
+                    drawing_file)
+
+    # Return error if drawing file not found
+    return make_response('File not found', 404)
 
 
 def read_drawing_info(artist_name, drawing_id):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,541 @@
+import json
+import os
+import re
+import time
+
+from server import app
+from utils.tests import CrystalPrismTestCase
+from uuid import UUID
+
+
+# Test /api/user endpoint [POST, GET, PATCH, DELETE]
+class TestUser(CrystalPrismTestCase):
+    def test_user_post_get_patch_and_soft_delete(self):
+        # Arrange [POST]
+        username = 'test1' + str(round(time.time()))
+        password = 'password'
+        post_data = {
+            'username': username,
+            'password': password
+            }
+
+        # Act [POST]
+        post_response = self.client.post(
+            '/api/user',
+            data=json.dumps(post_data),
+            content_type='application/json'
+            )
+        self.login(username, password)
+
+        # Assert [POST]
+        self.assertEqual(post_response.status_code, 201)
+
+        # Arrange [GET]
+        header = {'Authorization': 'Bearer ' + self.token}
+
+        # Act [GET]
+        get_response = self.client.get(
+            '/api/user',
+            headers=header
+            )
+        user_data = json.loads(get_response.get_data(as_text=True))
+
+        # Assert [GET]
+        self.assertEqual(get_response.status_code, 200)
+
+        # Ensure member_id is correct format
+        self.assertEqual(bool(UUID(
+            user_data['member_id'], version=4)), True
+            )
+
+        self.assertEqual(user_data['status'], 'active')
+        self.assertEqual(user_data['username'], username)
+        self.assertEqual(user_data['admin'], False)
+        self.assertEqual(user_data['first_name'], '')
+        self.assertEqual(user_data['last_name'], '')
+        self.assertEqual(user_data['name_public'], False)
+        self.assertEqual(user_data['email'], '')
+        self.assertEqual(user_data['email_public'], False)
+        self.assertEqual(user_data['background_color'], '#ffffff')
+        self.assertEqual(user_data['icon_color'], '#000000')
+        self.assertEqual(user_data['about'], '')
+        self.assertEqual(user_data['shapes_plays'], 0)
+        self.assertEqual(user_data['shapes_scores'], [])
+        self.assertEqual(user_data['shapes_high_score'], 0)
+        self.assertEqual(user_data['rhythm_plays'], 0)
+        self.assertEqual(user_data['rhythm_scores'], [])
+        self.assertEqual(user_data['rhythm_high_score'], 0)
+        self.assertEqual(user_data['rhythm_high_lifespan'], '00:00:00')
+        self.assertEqual(user_data['drawing_count'], 0)
+        self.assertEqual(user_data['liked_drawings'], [])
+        self.assertEqual(user_data['post_count'], 0)
+        self.assertEqual(user_data['comment_count'], 0)
+
+        # Ensure member since timestamp matches UTC format
+        timestamp_pattern = re.compile(
+            r'\d{4}-[0-1]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-6]\d.\d{6}\+\d\d:\d\d'
+            )
+        self.assertEqual(bool(timestamp_pattern.match(
+            user_data['member_since'])), True
+            )
+
+        # Arrange [PATCH]
+        updated_username = 'test2' + str(round(time.time()))
+        updated_password = 'password2'
+        patch_data = {
+            'username': updated_username,
+            'password': updated_password,
+            'about': 'Test',
+            'first_name': 'Test',
+            'last_name': 'Test',
+            'name_public': True,
+            'email': 'test@crystalprism.io',
+            'email_public': True,
+            'background_color': '#000000',
+            'icon_color': '#ffffff'
+            }
+
+        # Act [PATCH]
+        patch_response = self.client.patch(
+            '/api/user',
+            headers=header,
+            data=json.dumps(patch_data),
+            content_type='application/json'
+            )
+        patched_token = patch_response.get_data(as_text=True)
+        patched_header = {'Authorization': 'Bearer ' + patched_token}
+
+        patched_get_response = self.client.get(
+            '/api/user',
+            headers=patched_header
+            )
+        patched_user_data = json.loads(
+            patched_get_response.get_data(as_text=True)
+            )
+
+        patched_get_response_public = self.client.get(
+            '/api/user/' + updated_username
+            )
+        patched_user_data_public = json.loads(
+            patched_get_response_public.get_data(as_text=True)
+            )
+
+        # Assert [PATCH]
+        self.assertEqual(patch_response.status_code, 200)
+
+        # Ensure patched token is correct format
+        token_pattern = re.compile(
+            r'^[a-zA-Z0-9-_]+={0,2}\.[a-zA-Z0-9-_]+={0,2}' +
+            r'\.[a-zA-Z0-9-_]+={0,2}$'
+            )
+        self.assertEqual(bool(token_pattern.match(patched_token)), True)
+
+        self.assertEqual(patched_get_response.status_code, 200)
+        self.assertEqual(patched_get_response_public.status_code, 200)
+
+        self.assertEqual(patched_user_data['username'], updated_username)
+        self.assertEqual(patched_user_data['about'], 'Test')
+
+        self.assertEqual(patched_user_data['first_name'], 'Test')
+        self.assertEqual(patched_user_data['last_name'], 'Test')
+        self.assertEqual(patched_user_data['name_public'], True)
+        self.assertEqual(patched_user_data_public['name'], 'Test Test')
+
+        self.assertEqual(patched_user_data['email'], 'test@crystalprism.io')
+        self.assertEqual(patched_user_data['email_public'], True)
+        self.assertEqual(
+            patched_user_data_public['email'], 'test@crystalprism.io'
+            )
+
+        self.assertEqual(patched_user_data['background_color'], '#000000')
+        self.assertEqual(patched_user_data['icon_color'], '#ffffff')
+
+        # Act [DELETE]
+        delete_response = self.client.delete(
+            '/api/user',
+            headers=patched_header
+            )
+
+        deleted_get_response = self.client.get(
+            '/api/user',
+            headers=patched_header
+            )
+        error = deleted_get_response.get_data(as_text=True)
+
+        deleted_get_response_public = self.client.get(
+            '/api/user/' + updated_username
+            )
+        public_error = deleted_get_response_public.get_data(as_text=True)
+
+        # Assert [DELETE]
+        self.assertEqual(delete_response.status_code, 200)
+        self.assertEqual(deleted_get_response.status_code, 404)
+        self.assertEqual(error, 'Username does not exist')
+        self.assertEqual(deleted_get_response_public.status_code, 404)
+        self.assertEqual(public_error, 'Username does not exist')
+
+        # Hard-delete user for clean-up
+        self.delete_user_admin(updated_username)
+
+        # Ensure deleted user account isn't able to be deleted again
+        delete_again_response = self.client.delete(
+            '/api/user',
+            headers=patched_header
+            )
+        delete_error = delete_again_response.get_data(as_text=True)
+
+        self.assertEqual(delete_again_response.status_code, 404)
+        self.assertEqual(delete_error, 'Username does not exist')
+
+    def test_user_post_already_exists_error(self):
+        # Arrange
+        username = 'test3' + str(round(time.time()))
+        password = 'password'
+        self.create_user(username, password)
+        self.login(username, password)
+        header = {'Authorization': 'Bearer ' + self.token}
+        post_data = {
+            'username': username,
+            'password': password
+            }
+
+        # Soft-delete user
+        self.client.delete(
+            '/api/user',
+            headers=header
+            )
+
+        # Act
+        response = self.client.post(
+            '/api/user',
+            data=json.dumps(post_data),
+            content_type='application/json'
+            )
+        error = response.get_data(as_text=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(error, 'Username already exists')
+
+        # Hard-delete user for clean-up
+        self.delete_user_admin(username)
+
+    def test_user_patch_username_error(self):
+        # Arrange
+        username = 'test4' + str(round(time.time()))
+        self.create_user(username)
+        self.login(username)
+        header = {'Authorization': 'Bearer ' + self.token}
+        patch_data = {
+            'username': 'user',
+            'password': ''
+            }
+
+        # Act
+        response = self.client.patch(
+            '/api/user',
+            headers=header,
+            data=json.dumps(patch_data),
+            content_type='application/json'
+            )
+        error = response.get_data(as_text=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(error, 'Username already exists')
+
+        # Delete user for clean-up
+        self.delete_user(username)
+
+    def test_user_patch_soft_deleted_error(self):
+        # Arrange
+        username = 'test5' + str(round(time.time()))
+        self.create_user(username)
+        self.login(username)
+        header = {'Authorization': 'Bearer ' + self.token}
+        patch_data = {
+            'username': username,
+            'password': ''
+            }
+
+        # Soft-delete user
+        self.client.delete(
+            '/api/user',
+            headers=header
+            )
+
+        # Act
+        response = self.client.patch(
+            '/api/user',
+            headers=header,
+            data=json.dumps(patch_data),
+            content_type='application/json'
+            )
+        error = response.get_data(as_text=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(error, 'Username does not exist')
+
+        # Hard-delete user for clean-up
+        self.delete_user_admin(username)
+
+    def test_user_patch_hard_deleted_error(self):
+        # Arrange
+        username = 'test6' + str(round(time.time()))
+        self.create_user(username)
+        self.login(username)
+        header = {'Authorization': 'Bearer ' + self.token}
+        patch_data = {
+            'username': username,
+            'password': ''
+            }
+
+        # Hard-delete user
+        self.client.delete(
+            '/api/user/' + username,
+            headers=header
+            )
+
+        # Act
+        response = self.client.patch(
+            '/api/user',
+            headers=header,
+            data=json.dumps(patch_data),
+            content_type='application/json'
+            )
+        error = response.get_data(as_text=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(error, 'Username does not exist')
+
+    def test_user_get_error(self):
+        # Arrange
+        username = 'test7' + str(round(time.time()))
+        self.create_user(username)
+        self.login(username)
+        header = {'Authorization': 'Bearer ' + self.token}
+
+        # Delete user
+        self.client.delete(
+            '/api/user/' + username,
+            headers=header
+            )
+
+        # Act
+        response = self.client.get(
+            '/api/user',
+            headers=header
+            )
+        error = response.get_data(as_text=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(error, 'Username does not exist')
+
+    def test_public_user_get(self):
+        username = 'user'
+
+        # Act
+        get_response = self.client.get('/api/user/' + username)
+        user_data = json.loads(get_response.get_data(as_text=True))
+
+        # Assert [POST]
+        self.assertEqual(get_response.status_code, 200)
+        self.assertEqual(user_data['username'], username)
+        self.assertEqual(user_data['name'], '')
+        self.assertEqual(user_data['email'], '')
+        self.assertEqual(user_data['background_color'], '#ffffff')
+        self.assertEqual(user_data['icon_color'], '#000000')
+        self.assertEqual(user_data['about'], '')
+        self.assertEqual(
+            user_data['member_since'], '2017-10-04T00:00:00.000000+00:00'
+            )
+        self.assertEqual(user_data['shapes_high_score'], 55)
+        self.assertEqual(user_data['rhythm_high_lifespan'], '00:04:10')
+        self.assertEqual(user_data['drawing_count'], 10)
+        self.assertEqual(user_data['post_count'], 10)
+        self.assertEqual(user_data['comment_count'], 0)
+
+    def test_public_user_get_error(self):
+        username = 'fakeuseraccount' + str(round(time.time()))
+
+        # Act
+        response = self.client.get('/api/user/' + username)
+        error = response.get_data(as_text=True)
+
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(error, 'Username does not exist')
+
+    def test_user_hard_delete(self):
+        # Arrange - create two user accounts
+        first_username = 'test8' + str(round(time.time()))
+        self.create_user(first_username)
+        self.login(first_username)
+        first_user_header = {'Authorization': 'Bearer ' + self.token}
+
+        second_username = 'test9' + str(round(time.time()))
+        self.create_user(second_username)
+        self.login(second_username)
+        second_user_header = {'Authorization': 'Bearer ' + self.token}
+
+        # Arrange - first user creates drawing
+        test_drawing = os.path.dirname(__file__) + '/../fixtures/drawing.txt'
+        with open(test_drawing, 'r') as drawing:
+            drawing = drawing.read()
+        post_drawing_data = {
+            'drawing': drawing,
+            'title': 'Test'
+            }
+
+        self.client.post(
+            '/api/canvashare/drawing',
+            headers=first_user_header,
+            data=json.dumps(post_drawing_data),
+            content_type='application/json'
+            )
+
+        # Arrange - second user likes drawing
+        self.client.patch(
+            '/api/canvashare/drawing-info/' + first_username + '/1',
+            headers=second_user_header,
+            data=json.dumps({'request': 'like'}),
+            content_type='application/json'
+            )
+
+        # Arrange - first user likes a different drawing
+        self.client.patch(
+            '/api/canvashare/drawing-info/user/1',
+            headers=first_user_header,
+            data=json.dumps({'request': 'like'}),
+            content_type='application/json'
+            )
+
+        # Arrange - first user creates post
+        post_post_data = {
+            'title': 'Test',
+            'content': 'Test',
+            'public': True
+            }
+
+        post_post_response = self.client.post(
+            '/api/thought-writer/post',
+            headers=first_user_header,
+            data=json.dumps(post_post_data),
+            content_type='application/json'
+            )
+        timestamp = post_post_response.get_data(as_text=True)
+
+        # Arrange - first user posts score for Shapes in Rain
+        shapes_data = {'score': 100000}
+
+        self.client.post(
+            '/api/shapes-in-rain',
+            headers=first_user_header,
+            data=json.dumps(shapes_data),
+            content_type='application/json'
+            )
+
+        # Arrange - first user posts score for Rhythm of Life
+        rhythm_data = {
+            'score': 360000,
+            'lifespan': '100:00:00'
+            }
+
+        self.client.post(
+            '/api/rhythm-of-life',
+            headers=first_user_header,
+            data=json.dumps(rhythm_data),
+            content_type='application/json'
+            )
+
+        # Act - delete first user account
+        delete_response = self.client.delete(
+            '/api/user/' + first_username,
+            headers=first_user_header
+            )
+
+        # Assert
+        self.assertEqual(delete_response.status_code, 200)
+
+        # Ensure deleted user account isn't found when user is searched for
+        deleted_user_response = self.client.get(
+            '/api/user/' + first_username
+            )
+        deleted_error = deleted_user_response.get_data(as_text=True)
+
+        self.assertEqual(deleted_user_response.status_code, 404)
+        self.assertEqual(deleted_error, 'Username does not exist')
+
+        # Ensure deleted user account isn't able to be deleted again
+        delete_again_response = self.client.delete(
+            '/api/user/' + first_username,
+            headers=first_user_header
+            )
+        delete_again_error = deleted_user_response.get_data(as_text=True)
+
+        self.assertEqual(delete_again_response.status_code, 404)
+        self.assertEqual(delete_again_error, 'Username does not exist')
+
+        # Ensure deleted user's drawing is not found when searched for
+        deleted_drawing_response = self.client.get(
+            '/api/canvashare/drawing/' + first_username + '/1.png'
+            )
+        deleted_drawing_error = deleted_drawing_response.get_data(as_text=True)
+
+        self.assertEqual(deleted_drawing_response.status_code, 404)
+        self.assertEqual(deleted_drawing_error, 'File not found')
+
+        # Ensure deleted user's drawing is not in second user's liked drawings
+        # list
+        deleted_liker_response = self.client.get(
+            '/api/user',
+            headers=second_user_header
+            )
+        second_user_data = json.loads(
+            deleted_liker_response.get_data(as_text=True)
+            )
+        self.assertEqual(second_user_data['liked_drawings'], [])
+
+        # Ensure drawing that deleted user liked no longer contains deleted
+        # user as liked user
+        deleted_like_response = self.client.get(
+            '/api/canvashare/drawing-info/user/1'
+            )
+        drawing_response_data = json.loads(
+            deleted_like_response.get_data(as_text=True)
+            )
+        self.assertEqual(drawing_response_data['liked_users'], [])
+
+        # Ensure deleted user's post is not found when searched for
+        deleted_post_response = self.client.get(
+            '/api/thought-writer/post/' + first_username + '/' + timestamp
+            )
+
+        # Ensure deleted user does not appear in leaders data for Shapes in
+        # Rain
+        deleted_shapes_response = self.client.get('/api/shapes-in-rain')
+        shapes_response_data = json.loads(
+            deleted_shapes_response.get_data(as_text=True)
+            )
+        self.assertEqual(
+            shapes_response_data[0]['player'] != first_username, True
+            )
+
+        # Ensure deleted user does not appear in leaders data for Rhythm of
+        # Life
+        deleted_rhythm_response = self.client.get('/api/rhythm-of-life')
+        rhythm_response_data = json.loads(
+            deleted_rhythm_response.get_data(as_text=True)
+            )
+        self.assertEqual(
+            rhythm_response_data[0]['player'] != first_username, True
+            )
+
+        # Act - delete second user account for clean-up
+        delete_response = self.client.delete(
+            '/api/user/' + second_username,
+            headers=second_user_header
+            )

--- a/thought_writer/thought_writer.py
+++ b/thought_writer/thought_writer.py
@@ -253,6 +253,8 @@ def delete_post(requester):
 
 def read_post(writer_name, post_timestamp):
     # Convert username to member_id for post retrieval
+    writer_id = ''
+
     with open(cwd + '/../user/users.json', 'r') as users_file:
         users = json.load(users_file)
         for user_data in users:
@@ -287,8 +289,8 @@ def read_post(writer_name, post_timestamp):
 
                     return jsonify(post)
 
-            # If post is not found, return error to client
-            return make_response('Post not found', 404)
+        # If post is not found, return error to client
+        return make_response('Post not found', 404)
 
     # Retrieve post from public file otherwise
     with open(cwd + '/public/public.json', 'r') as public_file:
@@ -309,8 +311,8 @@ def read_post(writer_name, post_timestamp):
 
                 return jsonify(post)
 
-        # If post is not found, return error to client
-        return make_response('Post not found', 404)
+    # If post is not found, return error to client
+    return make_response('Post not found', 404)
 
 
 def create_comment(requester, writer_name, post_timestamp):

--- a/user/user.py
+++ b/user/user.py
@@ -485,8 +485,7 @@ def read_users():
     with open(cwd + '/users.json', 'r') as users_file:
         users = json.load(users_file)
         usernames = [user_data['username']
-            for user_data in users[request_start:request_end]
-            if user_data['status'] != 'deleted'
+            for user_data in users if user_data['status'] != 'deleted'
             ]
 
         return jsonify(usernames[request_start:request_end])

--- a/user/user.py
+++ b/user/user.py
@@ -149,6 +149,9 @@ def read_user(requester):
                             user_data['liked_drawings'][i] = str(
                                 artist['username'] + '/' + liked_file[-1])
 
+                # Remove password from user_data
+                user_data.pop('password')
+
                 return jsonify(user_data)
 
         # Return error if user account is not found


### PR DESCRIPTION
- Remove hashed password from `/api/user` [GET] response for security
- Add delete user as admin function
- Add delete admin user function for tear down
- Add error response for `/canvashare/drawing` [GET] endpoint if drawing is not found
- Update read_post function for `/thought-writer/post` [GET] endpoint to set writer_id variable as '' to prevent erroring out
- Update tabbing to return 404 response if writer's file is not found for `/thought-writer/post` [GET] endpoint
- Add tests for `/api/user` [POST, GET, PATCH, DELETE] endpoint
- Remove extraneous error from read_user function for GET method
- Add tests for `/api/user/verify` [GET] endpoint
- Add tests for `/api/users` [GET] endpoint
- Add "now" variable to specify time for unique username creation
- Add tests for `/api/login` [GET] endpoint
- Update all error responses for login endpoint to 401 "Unauthorized" for added security