### PR TITLE
Add error testing for `/api/canvashare` endpoints

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -608,7 +608,7 @@ class TestUser(CrystalPrismTestCase):
         deleted_drawing_error = deleted_drawing_response.get_data(as_text=True)
 
         self.assertEqual(deleted_drawing_response.status_code, 404)
-        self.assertEqual(deleted_drawing_error, 'File not found')
+        self.assertEqual(deleted_drawing_error, 'Not found')
 
         # Ensure deleted user's drawing is not in second user's liked drawings
         # list


### PR DESCRIPTION
- Remove extraneous setup functions from test classes
- Update drawing and drawing_info functions to make error responses if files are not found